### PR TITLE
Add robot + battery namespace

### DIFF
--- a/src/battery_discharge.cpp
+++ b/src/battery_discharge.cpp
@@ -89,16 +89,16 @@ void BatteryPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
     ROS_GREEN_STREAM("ROS node is up: " << node_name);
   }
 
-  // Publish a topic for charge level
-  this->charge_state_pub = this->rosNode->advertise<std_msgs::Float64>("charge_level", 1);
-  this->charge_state_mwh_pub = this->rosNode->advertise<std_msgs::Float64>("charge_level_mwh", 1);
-  this->charge_current_pub = this->rosNode->advertise<std_msgs::Float64>("charge_current", 1);
-  this->battery_voltage_pub = this->rosNode->advertise<std_msgs::Float64>("battery_voltage", 1);
-  this->battery_remaining_pub = this->rosNode->advertise<std_msgs::Float64>("battery_remaining", 1);
-
   std::string linkName = _sdf->Get<std::string>("link_name");
   this->link = this->model->GetLink(linkName);
   std::string batteryName = _sdf->Get<std::string>("battery_name");
+
+  // Publish a topic for charge level
+  this->charge_state_pub = this->rosNode->advertise<std_msgs::Float64>(batteryName + "/charge_level", 1);
+  this->charge_state_mwh_pub = this->rosNode->advertise<std_msgs::Float64>(batteryName + "/charge_level_mwh", 1);
+  this->charge_current_pub = this->rosNode->advertise<std_msgs::Float64>(batteryName + "/charge_current", 1);
+  this->battery_voltage_pub = this->rosNode->advertise<std_msgs::Float64>(batteryName + "/battery_voltage", 1);
+  this->battery_remaining_pub = this->rosNode->advertise<std_msgs::Float64>(batteryName + "/battery_remaining", 1);
 
   this->set_charging_srv =
       this->rosNode->advertiseService(batteryName + "/set_charging", &BatteryPlugin::SetCharging, this);


### PR DESCRIPTION
# Description

This PR adds a namespace composed of robot_name + battery_name for the topics and services of the battery plugin.

It's related to [this PR](https://github.com/RoboticaUtnFrba/create_autonomy/pull/243).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```bash
GUI=false roslaunch ca_gazebo create_empty_world..launch
```

**Test Configuration**:

- [ ] Real robot
- [X] Gazebo simulation

# Checklist:

- [x] My code follows the style guidelines of this project (Travis CI is passing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
