### PR TITLE
Throttle low battery message

### DIFF
--- a/src/ROS_debugging.h
+++ b/src/ROS_debugging.h
@@ -68,6 +68,8 @@ std::ostream& operator<<(std::ostream& os, PRINT_COLOR c)
 #define ROS_MAGENTA_STREAM(x) ROS_INFO_STREAM(pc::MAGENTA << x << pc::ENDCOLOR)
 #define ROS_CYAN_STREAM(x) ROS_INFO_STREAM(pc::CYAN << x << pc::ENDCOLOR)
 
+#define ROS_GREEN_STREAM_THROTTLE(x) ROS_INFO_STREAM_THROTTLE(1, pc::GREEN << x << pc::ENDCOLOR)
+
 #define ROS_BLACK_STREAM_COND(c, x) ROS_INFO_STREAM_COND(c, pc::BLACK << x << pc::ENDCOLOR)
 #define ROS_RED_STREAM_COND(c, x) ROS_INFO_STREAM_COND(c, pc::RED << x << pc::ENDCOLOR)
 #define ROS_GREEN_STREAM_COND(c, x) ROS_INFO_STREAM_COND(c, pc::GREEN << x << pc::ENDCOLOR)

--- a/src/battery_discharge.cpp
+++ b/src/battery_discharge.cpp
@@ -173,7 +173,7 @@ double BatteryPlugin::OnUpdateVoltage(const common::BatteryPtr& _battery)
 
   if (fabs(_battery->Voltage()) < 1e-3)
   {
-    ROS_GREEN_STREAM("BatteryPlugin::OnUpdateVoltage -> Battery Voltage is too low: " << _battery->Voltage());
+    ROS_GREEN_STREAM_THROTTLE("BatteryPlugin::OnUpdateVoltage -> Battery Voltage is too low: " << _battery->Voltage());
     return 0.0;
   }
   for (auto powerLoad : _battery->PowerLoads())


### PR DESCRIPTION
When the battery runs out, the plugin starts publishing a lot of messages. This change limits the publication to 1 per second.